### PR TITLE
Fixing source term bugs

### DIFF
--- a/Hydro/euler.c
+++ b/Hydro/euler.c
@@ -192,6 +192,12 @@ void source( double * prim , double * cons , double * xp , double * xm , double 
  
    if( include_viscosity ){
       double nu = explicit_viscosity;
+      if( alpha_flag ){
+         double alpha = explicit_viscosity;
+         double c = sqrt( gamma_law*prim[PPP]/prim[RHO] );
+         double h = c*pow( r_1 , 1.5 );
+         nu = alpha*c*h;
+      }
       cons[SRR] += -dVdt*nu*rho*vr/(r_1*r_1);
    }
 
@@ -280,7 +286,26 @@ double mindt(double * prim , double w , double * xp , double * xm ){
    double dt = dtr;
    if( dt > dtp ) dt = dtp;
    if( dt > dtz ) dt = dtz;
+/*
+   double dL0 = get_dL(xp,xm,0);
+   double dL1 = get_dL(xp,xm,1);
+   double dL2 = get_dL(xp,xm,2);
+   double dx = dL0;
+   if( dx>dL1 ) dx = dL1;
+   if( dx>dL2 ) dx = dL2;
 
+   double nu = explicit_viscosity;
+
+   if( alpha_flag ){
+      double alpha = explicit_viscosity;
+      double c = sqrt( gamma_law*prim[PPP]/prim[RHO] );
+      double h = c*pow( r , 1.5 );
+      nu = alpha*c*h;
+   }
+
+   double dt_visc = .03*dx*dx/nu;
+   if( dt > dt_visc ) dt = dt_visc;
+*/
    return( dt );
 
 }

--- a/planet.c
+++ b/planet.c
@@ -60,8 +60,8 @@ void planetaryForce( struct planet * pl , double r , double phi , double z , dou
 
    double f1 = -fgrav( pl->M , script_r , pl->eps );
 
-   double cosa = dx/script_r;
-   double sina = dy/script_r;
+   double cosa = dx/script_r_perp;
+   double sina = dy/script_r_perp;
 
    double cosap = cosa*cosp+sina*sinp;
    double sinap = sina*cosp-cosa*sinp;


### PR DESCRIPTION
This brings nyu up to date with duffell/Disco and fixes a bug in the gravitational source terms.
- The viscous source term in euler.c now properly incorporates an alpha-law viscosity.
- The gravitational force from point masses in planet.c is now calculated correctly in 3D.  Previously only 2D gravity was correct.